### PR TITLE
Grant access to Book object

### DIFF
--- a/force-app/main/default/layouts/Book__c-Book Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Book__c-Book Layout.layout-meta.xml
@@ -10,6 +10,22 @@
                 <behavior>Required</behavior>
                 <field>Name</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Author__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Edition__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Summary__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ISBN__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/layouts/Book__c-Book Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Book__c-Book Layout.layout-meta.xml
@@ -26,6 +26,14 @@
                 <behavior>Edit</behavior>
                 <field>ISBN__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Genre__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Date_Published__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/Book__c/fields/Author__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Author__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Author__c</fullName>
+    <defaultValue>&quot;Unknown Author&quot;</defaultValue>
+    <description>Name of the author</description>
+    <externalId>false</externalId>
+    <label>Author</label>
+    <length>50</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/Date_Published__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Date_Published__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Date_Published__c</fullName>
+    <description>Date of first publication</description>
+    <externalId>false</externalId>
+    <label>Date Published</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Date</type>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/Edition__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Edition__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Edition__c</fullName>
+    <description>Version of a book title.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>e.g. 5th Edition</inlineHelpText>
+    <label>Edition</label>
+    <length>50</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/Genre__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Genre__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Genre__c</fullName>
+    <description>Category the book falls under</description>
+    <externalId>false</externalId>
+    <label>Genre</label>
+    <length>50</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/ISBN__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/ISBN__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ISBN__c</fullName>
+    <description>International Standard Book Number used to identify the book. Usually appears as a barcode</description>
+    <externalId>true</externalId>
+    <inlineHelpText>An example of an ISBN-13 number would be 978-3-16-148410-0
+Books before 2007 use ISBN-10 such as  0-545-01022-5</inlineHelpText>
+    <label>ISBN</label>
+    <length>17</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Book__c/fields/Summary__c.field-meta.xml
+++ b/force-app/main/default/objects/Book__c/fields/Summary__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Summary__c</fullName>
+    <description>A paragraph or two describing the book contents</description>
+    <externalId>false</externalId>
+    <label>Summary</label>
+    <length>32768</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/permissionsets/Admin_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Admin_Access.permissionset-meta.xml
@@ -2,7 +2,7 @@
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>Specifies who has access to the Cheltham library books</description>
     <hasActivationRequired>false</hasActivationRequired>
-    <label>Book Access</label>
+    <label>Admin Access</label>
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>true</allowDelete>

--- a/force-app/main/default/permissionsets/Book_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Book_Access.permissionset-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Specifies who has access to the Cheltham library books</description>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Book Access</label>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>Book__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <tabSettings>
+        <tab>Book__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+</PermissionSet>


### PR DESCRIPTION
The newly created permission set provides access to the Book entity (Tab and Object). This will fix the problem of creating new scratch orgs without the required permission sets. In order to use the newly created permission set, use the force:user:permset:assign command when you create a new scratch org.

Usage via CLI example:

`sfdx force:user:permset:assign -n Book_Access`
(This will just result in a Duplicate Assignment Error if called again once the user already the Book Access permissions)

Open your scratch org and verify that you can access the `Book` Tab