### PR TITLE
Grant the admin full rights to the Book object

### DIFF
--- a/force-app/main/default/permissionsets/Admin_Permission_Sets.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Admin_Permission_Sets.permissionset-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Giving admins access to the custom tabs and objects.</description>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Admin Permission Sets</label>
+    <objectPermissions>
+        <allowCreate>true</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Book__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <tabSettings>
+        <tab>Book__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+</PermissionSet>


### PR DESCRIPTION
The newly created permission set provides access to the Book entity (Tab and Object). This will fix the problem of creating new scratch orgs without the required permission sets. In order to use the newly created permission set, use the force:user:permset:assign command when you create a new scratch org.

Usage via CLI example:

`sfdx force:user:permset:assign -n Admin_Permission_Sets`

Open your scratch org and verify that you can access the `Book` Tab