### PR TITLE
Create Library Member Access permission set

### DIFF
--- a/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
@@ -1,6 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
     <description>Read-only permissions to be given to the regular users of the Cheltham Library</description>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.Author__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.Date_Published__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.Edition__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.Genre__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.ISBN__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Book__c.Summary__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Library Member Access</label>
     <objectPermissions>

--- a/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Read-only permissions to be given to the regular users of the Cheltham Library</description>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Library Member Access</label>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Book_Copy__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
+        <object>Book__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <tabSettings>
+        <tab>Book__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+</PermissionSet>


### PR DESCRIPTION
Creates a read-only permission set for library member access. 

This is so non-admin permissions can be tested so as to close #29 and any other future issues involving non-admins. A custom user can be made in a scratch org and given the Library Member Access permissions.
Note that the default user uses the System Administrator profile, which overrides the read-only settings for this permission set.