### PR TITLE
delete Book Copy description permissions as the field no longer exists

### DIFF
--- a/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
@@ -13,11 +13,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Book__c.Description__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Book__c.Edition__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Deleted Book description permissions from the new Library Member permission set so as to fix a deploy error due to the Description field being recently deleted.