### PR TITLE
Isbn validator

### DIFF
--- a/force-app/main/default/classes/ISBNValidator.cls
+++ b/force-app/main/default/classes/ISBNValidator.cls
@@ -1,0 +1,139 @@
+public class ISBNValidator {
+    
+    private static final List<Integer> ThirteenISBN_weights = new List<Integer>{1,3,1,3,1,3,1,3,1,3,1,3,1};
+    private static final List<Integer> TenISBN_weights = new List<Integer>{10,9,8,7,6,5,4,3,2,1};
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////      
+   public static void checkAndUpdatebookIsbn(List<Book__c> books){
+       for(Book__c book: books){
+           if(book.ISBN__c == NULL){
+               continue;
+           }
+           String bookIsbn = String.valueOf(book.ISBN__c);
+           if(isValid(bookIsbn)){
+               if(bookIsbn.length() == 10){
+                   book.ISBN__c = convert10DigitIsbnTo13Digit(bookIsbn);
+               }
+               
+           }
+           else{
+              book.ISBN__c.addError('This is not a valid ISBN. A valid ISBN is a 13 or 10 digit code'); 
+           }
+       }     
+   }
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////      
+    public static boolean isValid(string ISBN){
+        Integer isbnLength = ISBN.length();
+        if(hasCorrectFormat(ISBN, isbnLength)){
+            if(checkISBNValidation(ISBN, isbnLength)){
+                return true;
+            }
+        }
+        return false;
+    }
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////   
+    public static boolean hasCorrectFormat(String ISBN, Integer isbnLength){
+        //Pattern legitimate_ISBN_pattern;
+        if(isbnLength == 13){
+            if(Pattern.matches('[0-9]{13}',ISBN)){
+                return true;
+            }
+            return false;
+        }
+        else if(isbnLength == 10){
+            if(Pattern.matches('[0-9]{9}[0-9Xx]',ISBN)){
+                return true;
+            }
+            return false;
+        }
+        else{
+            return false;
+        }
+    } 
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////   
+    public static boolean checkISBNValidation(String ISBN, Integer isbnLength){
+        if(isbnLength == 10){
+            if(is10DigitIsbnValid(ISBN)){
+                return true;
+            }
+            else{
+                return false;
+            }
+        }
+        if(is13DigitIsbnValid(ISBN)){
+            return true;
+        }
+        return false;
+    }
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean is13DigitIsbnValid(String ISBN){
+        List<String> separatedIsbnInDigits = ISBN.split('');
+        Integer weightedSum = 0;
+        Integer isbnWeightsIndex = 0;
+                
+        for(String singleDigit: separatedIsbnInDigits){
+            weightedSum  += Integer.valueOf(singleDigit)* ThirteenISBN_weights[isbnWeightsIndex];
+            isbnWeightsIndex++;
+        }
+            
+        if(math.mod(weightedSum, 10) == 0){
+            return true;
+        }
+        return false;
+    }
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean is10DigitIsbnValid(String ISBN){
+        Integer weightedSum = 0;
+        List<String> separatedIsbnInDigits = ISBN.split('');
+        if(separatedIsbnInDigits[separatedIsbnInDigits.size()-1].toUpperCase() == 'X'){
+            weightedSum = 10;
+            separatedIsbnInDigits.remove(separatedIsbnInDigits.size()-1);
+            
+        }
+        Integer isbnWeightsIndex = 0;
+                
+        for(String singleDigit: separatedIsbnInDigits){
+            weightedSum  += Integer.valueOf(singleDigit)* TenISBN_weights[isbnWeightsIndex];
+            isbnWeightsIndex++;
+        }
+            
+        if(math.mod(weightedSum, 11) == 0){
+            return true;
+        }
+        return false;
+    }
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static string convert10DigitIsbnTo13Digit(String ISBN){
+        List<String> separatedIsbnInDigits = ISBN.split('');
+        separatedIsbnInDigits.add(0, '978');
+        ISBN = String.join(separatedIsbnInDigits , '');
+        
+        String expectedCheckDigit = findTheCorrectLastDigitOfConverted10DigitIsbn(ISBN);
+        separatedIsbnInDigits.remove(separatedIsbnInDigits.size() -1);
+        separatedIsbnInDigits.add(expectedCheckDigit);
+        
+        return String.join(separatedIsbnInDigits, '');
+    }
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  // This method assumes the 13 digit ISBN parameter has potentially the wrong format,i.e. contains no letter except X at the end
+    public static string findTheCorrectLastDigitOfConverted10DigitIsbn(String ISBN){
+        List<String> separatedIsbnInDigits = ISBN.split('');
+        separatedIsbnInDigits.remove(separatedIsbnInDigits.size()-1);
+        Integer lastDigit = 0;
+        Integer isbnWeightsIndex = 0;
+                
+        for(String singleDigit: separatedIsbnInDigits){
+            lastDigit  += Integer.valueOf(singleDigit)* ThirteenISBN_weights[isbnWeightsIndex];
+            isbnWeightsIndex++;
+        }
+        lastDigit = math.mod(10 - math.mod(lastDigit, 10 ), 10);
+        return String.valueOf(lastDigit);
+    }
+}

--- a/force-app/main/default/classes/ISBNValidator.cls-meta.xml
+++ b/force-app/main/default/classes/ISBNValidator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ISBNValidatorUtility.cls
+++ b/force-app/main/default/classes/ISBNValidatorUtility.cls
@@ -1,0 +1,65 @@
+@isTest
+public class ISBNValidatorUtility {
+	@isTest
+    public static List<String> createCorrectlyFormattedWithInvalidISBNs(){
+        List<String> correctlyFormattedWithInvalidISBNs = new List<String>();
+        correctlyFormattedWithInvalidISBNs.add('1111111112');
+        correctlyFormattedWithInvalidISBNs.add('900000000X');
+        correctlyFormattedWithInvalidISBNs.add('9789878767421');
+        correctlyFormattedWithInvalidISBNs.add('900000000x');
+        
+        return correctlyFormattedWithInvalidISBNs;
+    }
+    @isTest
+    public static List<String> createValidISBNs(){
+        List<String> validISBNs = new List<String>();
+        validISBNs.add('1111111111');
+        validISBNs.add('900002000X');
+        validISBNs.add('900002000x');
+        validISBNs.add('9780747546245');
+        
+        return validISBNs;
+    }
+    @isTest
+    public static List<String> createIncorrectlyFormattedISBNs(){
+        List<String> incorrectlyFormattedISBNs = new List<String>();
+        incorrectlyFormattedISBNs.add('12345678XX');
+        incorrectlyFormattedISBNs.add('xc`~\\`!1@4%5');
+        incorrectlyFormattedISBNs.add('900002000A');
+        incorrectlyFormattedISBNs.add('90000200031');
+        incorrectlyFormattedISBNs.add('97807475462450');
+        
+        return incorrectlyFormattedISBNs;
+    }
+    @isTest
+	public static List<book__c> createBookWithCorrectlyFormattedWithInvalidISBNs(){
+        List<book__c> bookWithCorrectlyFormattedWithInvalidISBNs = new List<book__c>();
+        bookWithCorrectlyFormattedWithInvalidISBNs.add(new book__c(ISBN__c = '1111111112'));
+        bookWithCorrectlyFormattedWithInvalidISBNs.add(new book__c(ISBN__c = '900000000X'));
+        bookWithCorrectlyFormattedWithInvalidISBNs.add(new book__c(ISBN__c = '9789878767421'));
+        bookWithCorrectlyFormattedWithInvalidISBNs.add(new book__c(ISBN__c = '900000000x'));
+        
+        return bookWithCorrectlyFormattedWithInvalidISBNs;
+    }
+    @isTest
+    public static List<book__c> createBookWithValidISBNs(){
+        List<book__c> bookWithValidISBNs = new List<book__c>();
+        bookWithValidISBNs.add(new book__c(ISBN__c = '1111111111'));
+        bookWithValidISBNs.add(new book__c(ISBN__c = '900002000X'));
+        bookWithValidISBNs.add(new book__c(ISBN__c = '900002000x'));
+        bookWithValidISBNs.add(new book__c(ISBN__c = '9780747546245'));
+        
+        return bookWithValidISBNs;
+    }
+    @isTest
+    public static List<book__c> createBookWithIncorrectlyFormattedISBNs(){
+        List<book__c> bookWithIncorrectlyFormattedISBNs = new List<book__c>();
+        bookWithIncorrectlyFormattedISBNs.add(new book__c(ISBN__c = '12345678XX'));
+        bookWithIncorrectlyFormattedISBNs.add(new book__c(ISBN__c = 'xc`~\\`!1@4%5'));
+        bookWithIncorrectlyFormattedISBNs.add(new book__c(ISBN__c = '900002000A'));
+        bookWithIncorrectlyFormattedISBNs.add(new book__c(ISBN__c = '90000200031'));
+        bookWithIncorrectlyFormattedISBNs.add(new book__c(ISBN__c = '97807475462450'));
+        
+        return bookWithIncorrectlyFormattedISBNs;
+    }
+}

--- a/force-app/main/default/classes/ISBNValidatorUtility.cls-meta.xml
+++ b/force-app/main/default/classes/ISBNValidatorUtility.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/testISBNValidator.cls
+++ b/force-app/main/default/classes/testISBNValidator.cls
@@ -1,0 +1,130 @@
+@isTest
+private class testISBNValidator {
+    @isTest
+    static void testFindTheCorrectLastDigitOfConvertedIsbn(){
+        List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+        List<String> correctlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createCorrectlyFormattedWithInvalidISBNs();
+        
+        system.assertEquals('3', ISBNValidator.findTheCorrectLastDigitOfConverted10DigitIsbn('9781111111111'));
+        system.assertEquals('3', ISBNValidator.findTheCorrectLastDigitOfConverted10DigitIsbn('978900002000X'));
+        system.assertEquals('3', ISBNValidator.findTheCorrectLastDigitOfConverted10DigitIsbn('978900002000x'));
+    }
+    @isTest
+    static void testConvert10DigitIsbnTo13Digit(){
+       	List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+        
+       	system.assertEquals('9781111111113', ISBNValidator.convert10DigitIsbnTo13Digit(validISBNs[0]));
+        system.assertEquals('9789000020003', ISBNValidator.convert10DigitIsbnTo13Digit(validISBNs[1]));
+        
+    }
+    @isTest
+    static void testIs10DigitIsbnValid(){
+       	List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+       	List<String> correctlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createCorrectlyFormattedWithInvalidISBNs();
+        
+       	system.assertEquals(true, ISBNValidator.is10DigitIsbnValid(validISBNs[0]));
+        system.assertEquals(true, ISBNValidator.is10DigitIsbnValid(validISBNs[1]));
+        system.assertEquals(false, ISBNValidator.is10DigitIsbnValid(correctlyFormattedWithInvalidISBNs[0]));
+        system.assertEquals(false, ISBNValidator.is10DigitIsbnValid(correctlyFormattedWithInvalidISBNs[1]));
+        system.assertEquals(false, ISBNValidator.is10DigitIsbnValid(correctlyFormattedWithInvalidISBNs[3]));
+        
+    }
+    @isTest
+    static void testIs13DigitIsbnValid(){
+       	List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+       	List<String> correctlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createCorrectlyFormattedWithInvalidISBNs();
+        
+        system.assertEquals(true, ISBNValidator.is13DigitIsbnValid(validISBNs[3]));
+        system.assertEquals(false, ISBNValidator.is13DigitIsbnValid(correctlyFormattedWithInvalidISBNs[2]));
+    }
+    @isTest
+    static void testCheckISBNValidation(){
+       	List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+       	List<String> correctlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createCorrectlyFormattedWithInvalidISBNs();
+        List<String> incorrectlyFormattedISBNs = ISBNValidatorUtility.createincorrectlyFormattedISBNs();
+        
+        system.assertEquals(true, ISBNValidator.checkISBNValidation(validISBNs[0], 10));
+        system.assertEquals(true, ISBNValidator.checkISBNValidation(validISBNs[3], 13));
+        system.assertEquals(false, ISBNValidator.checkISBNValidation(correctlyFormattedWithInvalidISBNs[0], 10));
+        system.assertEquals(false, ISBNValidator.checkISBNValidation(correctlyFormattedWithInvalidISBNs[2], 13));
+        system.assertEquals(false, ISBNValidator.checkISBNValidation(incorrectlyFormattedISBNs[3], 11));
+    }
+    @isTest
+    static void testHasCorrectFormat(){
+       List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+       	List<String> correctlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createCorrectlyFormattedWithInvalidISBNs();
+        List<String> incorrectlyFormattedISBNs = ISBNValidatorUtility.createincorrectlyFormattedISBNs();
+        
+        system.assertEquals(true, ISBNValidator.hasCorrectFormat(validISBNs[0], 10));
+        system.assertEquals(true, ISBNValidator.hasCorrectFormat(validISBNs[3], 13));
+        system.assertEquals(true, ISBNValidator.hasCorrectFormat(correctlyFormattedWithInvalidISBNs[0], 10));
+        system.assertEquals(true, ISBNValidator.hasCorrectFormat(correctlyFormattedWithInvalidISBNs[2], 13));
+        system.assertEquals(false, ISBNValidator.hasCorrectFormat(incorrectlyFormattedISBNs[0], 10));
+        system.assertEquals(false, ISBNValidator.hasCorrectFormat(incorrectlyFormattedISBNs[1], 13));
+        system.assertEquals(false, ISBNValidator.hasCorrectFormat(incorrectlyFormattedISBNs[2], 10));
+        system.assertEquals(false, ISBNValidator.hasCorrectFormat(incorrectlyFormattedISBNs[3], 11));
+        system.assertEquals(false, ISBNValidator.hasCorrectFormat(incorrectlyFormattedISBNs[4], 14)); 
+    }
+    @isTest
+    static void testIsValid(){
+       	List<String> validISBNs = ISBNValidatorUtility.createValidISBNs();
+       	List<String> correctlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createCorrectlyFormattedWithInvalidISBNs();
+        List<String> incorrectlyFormattedISBNs = ISBNValidatorUtility.createIncorrectlyFormattedISBNs();
+        
+        system.assertEquals(ISBNValidator.isValid(validISBNs[0]), true);
+        system.assertEquals(ISBNValidator.isValid(validISBNs[1]), true);
+        
+        system.assertEquals(ISBNValidator.isValid(correctlyFormattedWithInvalidISBNs[0]), false);
+        system.assertEquals(ISBNValidator.isValid(correctlyFormattedWithInvalidISBNs[1]), false);
+        system.assertEquals(ISBNValidator.isValid(correctlyFormattedWithInvalidISBNs[2]), false);
+        system.assertEquals(ISBNValidator.isValid(correctlyFormattedWithInvalidISBNs[3]), false);
+        
+        system.assertEquals(ISBNValidator.isValid(incorrectlyFormattedISBNs[0]), false);
+        system.assertEquals(ISBNValidator.isValid(incorrectlyFormattedISBNs[1]), false);
+        system.assertEquals(ISBNValidator.isValid(incorrectlyFormattedISBNs[2]), false);
+        system.assertEquals(ISBNValidator.isValid(incorrectlyFormattedISBNs[3]), false);
+    }
+    @isTest
+    static void testcheckAndUpdatebookIsbn(){
+       	List<book__c> bookWithValidISBNs = ISBNValidatorUtility.createBookWithValidISBNs();
+       	List<book__c> bookWithCorrectlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createBookWithCorrectlyFormattedWithInvalidISBNs();
+        List<book__c> bookWithIncorrectlyFormattedISBNs = ISBNValidatorUtility.createBookWithIncorrectlyFormattedISBNs();
+        
+        ISBNValidator.checkAndUpdatebookIsbn(bookWithValidISBNs);
+        system.assertEquals('9781111111113', String.valueOf(bookWithValidISBNs[0].ISBN__c));
+        system.assertEquals('9789000020003', String.valueOf(bookWithValidISBNs[2].ISBN__c));
+        
+        try{
+            ISBNValidator.checkAndUpdatebookIsbn(bookWithCorrectlyFormattedWithInvalidISBNs);
+        }catch(Exception error){
+            system.assert(error.getMessage().contains('This is not a valid ISBN. A valid ISBN is a 13 or 10 digit code'));
+        }
+        
+        try{
+            ISBNValidator.checkAndUpdatebookIsbn(bookWithIncorrectlyFormattedISBNs);
+        }catch(Exception error){
+            system.assert(error.getMessage().contains('This is not a valid ISBN. A valid ISBN is a 13 or 10 digit code'));
+        }
+    }
+    
+    @isTest
+    static void testISBN_validation(){
+       	List<book__c> bookWithValidISBNs = ISBNValidatorUtility.createBookWithValidISBNs();
+       	List<book__c> bookWithCorrectlyFormattedWithInvalidISBNs = ISBNValidatorUtility.createBookWithCorrectlyFormattedWithInvalidISBNs();
+        List<book__c> bookWithIncorrectlyFormattedISBNs = ISBNValidatorUtility.createBookWithIncorrectlyFormattedISBNs();
+        
+        try{
+            insert bookWithCorrectlyFormattedWithInvalidISBNs;
+        }
+        catch(Exception error){
+            system.assert(error.getMessage().contains('This is not a valid ISBN. A valid ISBN is a 13 or 10 digit code'));
+        }
+        
+        try{
+            insert bookWithIncorrectlyFormattedISBNs;
+        }
+        catch(Exception error){
+            system.assert(error.getMessage().contains('This is not a valid ISBN. A valid ISBN is a 13 or 10 digit code'));
+        }
+    }
+}

--- a/force-app/main/default/classes/testISBNValidator.cls-meta.xml
+++ b/force-app/main/default/classes/testISBNValidator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
@@ -13,7 +13,7 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Book__c.Description__c</field>
+        <field>Book__c.Summary__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Library_Member_Access.permissionset-meta.xml
@@ -13,14 +13,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-<<<<<<< HEAD
-        <field>Book__c.Summary__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
-=======
->>>>>>> b366795518525cc408d6ee53a2d35d4c30a15602
         <field>Book__c.Edition__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/triggers/ISBN_validation.trigger
+++ b/force-app/main/default/triggers/ISBN_validation.trigger
@@ -1,0 +1,3 @@
+trigger ISBN_validation on Book__c (before insert, before update) {
+    ISBNValidator.checkAndUpdatebookIsbn(trigger.new);
+}

--- a/force-app/main/default/triggers/ISBN_validation.trigger-meta.xml
+++ b/force-app/main/default/triggers/ISBN_validation.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>47.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
This version of <b>ISBNValidator</b> class has been <b> refactored </b> and its test classes have been redesigned to avoid using fuzzy testing techniques. The class has broken down into two main methods:

1. <b>hasCorrectFormat()</b>: Checks whether the ISBN code has a <b>proper length</b>, or <b>only contains digits</b>, and even in some 10 digit ISBN cases whether there is X at the end, etc. The method <b>does not care </b>. whether <b> x </b> is capitalised or not,

2. <b> checkISBNValidation()</b>: Checks whether ISBN can be a correct ISBN but checking the checksum against the rest of the 12 or 9 digit code.

For the sake of <b>consistency</b> and <b>ease</b> of use, every 10 digit ISBN will <b>always</b> be converted to its 13 digit equivalent ISBN code.

For further information how the conversion formula works, please refer to following [http://mathworld.wolfram.com/ISBN.html](url)